### PR TITLE
Fixed defer

### DIFF
--- a/main.go
+++ b/main.go
@@ -441,8 +441,10 @@ func validateEmail(email string) string {
 			continue
 		}
 
-		defer c.Quit()
-		defer c.Close()
+		defer func() {
+			c.Quit()
+			c.Close()
+		}()
 
 		if err = c.Hello(domainName); err != nil {
 			return veResVal(email, err.Error())


### PR DESCRIPTION
`defer` statements are called in reverse order. Therefor this will call `c.Close()` and then `c.Quit()`, the opposite of what we want:
```go
defer c.Quit()
defer c.Close()
```

Wrapped in anonymous func to get desired order:
```go
defer func() {
  c.Quit()
  c.Close()
}()
```